### PR TITLE
Added VS container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "energym",
+	"build": {
+		"args": {"ENERGYPLUS_VERSION":"8.6.0", "ENERGYPLUS_INSTALL_VERSION":"8-6-0", "ENERGYPLUS_SHA":"198c6a3cff"},
+	},
+	"dockerFile": "../Dockerfile",
+	"context": "..",
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+}


### PR DESCRIPTION
Added Visual Studio Code container configuration (check `.devcontainer/devcontainer.json`). It allows you to _build_ and _run_ a development container inside Visual Studio Code.