### PR TITLE
LoggerEvalCallback compatibility for recurrent policies

### DIFF
--- a/sinergym/utils/callbacks.py
+++ b/sinergym/utils/callbacks.py
@@ -242,14 +242,20 @@ class LoggerEvalCallback(EventCallback):
 
         for _ in range(self.n_eval_episodes):
             obs, _ = self.eval_env.reset()
-            state, truncated, terminated = None, False, False
+            truncated, terminated = False, False
+            state = None
+            ep_done = False
 
             # ------------------- Running episode and accumulate values ------------------ #
-            while not (truncated or terminated):
+            while not ep_done:
                 action, state = self.model.predict(
-                    obs, state=state, deterministic=self.deterministic
+                    obs,
+                    state=state,
+                    episode_start=ep_done,
+                    deterministic=self.deterministic,
                 )
                 obs, _, terminated, truncated, _ = self.eval_env.step(action)
+                ep_done = terminated or truncated
 
             # ------------------- Storing last episode in results dict ------------------- #
             summary = self.eval_env.get_wrapper_attr('get_episode_summary')()


### PR DESCRIPTION
## 🚀 Description

Compatibility with `MlpLstmPolicy` has been added to `LoggerEvalCallback`.

## 🔄 Types of Changes
<!-- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (change that alters existing functionality)
- [ ] 📖 Documentation update
- [x] 🔧 Improvement (enhancement of an existing feature)
- [ ] 🏷️ Other (please specify below)


<!-- Provide a brief explanation -->
The private method `_evaluate_policy()` in `LoggerEvalCallback` now contains the variable `ep_done`, which controls whether the episode has ended or been truncated. 

This is introduced in the call to `self.model.predict(..., episode_start=ep_done)` during evaluation, so that the model is aware of the start/end of the episode.

This is particularly relevant for the correct functioning of Stable Baselines3 algorithms implementing `MlpLstmPolicy`, as indicated in https://sb3-contrib.readthedocs.io/en/master/modules/ppo_recurrent.html.

As a side note, it is also important to include hidden states in the `.predict()` method, something that was already done in the implementation of `_evaluate_policy()`.   

---

## ✅ Checklist
<!-- Go through the following points and check all that apply. -->
<!-- If you're unsure about any, feel free to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTION GUIDE](https://github.com/ugr-sail/sinergym/blob/main/CONTRIBUTING.md) (**required**).
- [ ] My changes require an update in the documentation.
- [ ] I have updated the tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `black --check <project-root-path>`.
- [ ] I have reformatted the code using `ruff check <project-root-path>`.
- [ ] I have ensured `cd docs && make spelling && make html` passes (**required** if documentation was updated).
- [ ] I have ensured `pytest tests/ -vv` passes (**required**).
- [ ] I have ensured `pyright <project-root-path>` passes (**required**).

---

## 📜 Automatic Changelog

<!-- 🚨 DO NOT EDIT: This section will be automatically populated with commit messages. -->

<details>
  <summary>🔽 Click to view changelog</summary>
  <!-- GitHub Actions will insert commit messages here -->
</details>