### PR TITLE
HOTFIX - Allow int values in OU noise definition

### DIFF
--- a/sinergym/config/modeling.py
+++ b/sinergym/config/modeling.py
@@ -410,12 +410,12 @@ class ModelJSON(object):
                             processed_params.append(
                                 float(np.random.uniform(param[0], param[1]))
                             )
-                        elif isinstance(param, float):
+                        elif isinstance(param, (float, int)):
                             processed_params.append(float(param))
                         else:
                             raise ValueError(
                                 f'Invalid parameter for Ornstein-Uhlenbeck process: {param}. '
-                                'It must be a tuple or a float.'
+                                'It must be a tuple or a float/int.'
                             )
                     # var_range stays as-is
                     else:


### PR DESCRIPTION
## 🚀 Description

This hotfix allows int values in OU noise definition, giving more user definition flexibility with Sinergym.

Thanks to @manjavacas for notifying the error :)

---

## 🔄 Types of Changes
<!-- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (change that alters existing functionality)
- [ ] 📖 Documentation update
- [ ] 🔧 Improvement (enhancement of an existing feature)
- [ ] 🏷️ Other (please specify below)

If "Other," please describe:  
<!-- Provide a brief explanation -->

---

## ✅ Checklist
<!-- Go through the following points and check all that apply. -->
<!-- If you're unsure about any, feel free to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTION GUIDE](https://github.com/ugr-sail/sinergym/blob/main/CONTRIBUTING.md) (**required**).
- [ ] My changes require an update in the documentation.
- [ ] I have updated the tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `black --check <project-root-path>`.
- [ ] I have reformatted the code using `ruff check <project-root-path>`.
- [ ] I have ensured `cd docs && make spelling && make html` passes (**required** if documentation was updated).
- [ ] I have ensured `pytest tests/ -vv` passes (**required**).
- [ ] I have ensured `pyright <project-root-path>` passes (**required**).

---


## 📜 Automatic Changelog

<details>
  <summary>🔽 Click to view changelog</summary>

- Fix to allow int values in ou parameters definition
</details>
