### PR TITLE
Prevent error when WandBLogger is not used

### DIFF
--- a/scripts/train/local_confs/train_agent_local_conf.py
+++ b/scripts/train/local_confs/train_agent_local_conf.py
@@ -264,9 +264,10 @@ try:
 
         # By default, the evaluation environment does not use WandBLogger
         if wrappers:
-            key_to_remove = [key for key in wrappers if 'WandBLogger' in key][0]
-            del wrappers[key_to_remove]
-            logger.info(f'Wrappers updated without WandBLogger for evaluations')
+            wandb_keys = [key for key in wrappers if 'WandBLogger' in key]
+            if wandb_keys:
+                del wrappers[wandb_keys[0]]
+                logger.info(f'Wrappers updated without WandBLogger for evaluations')
 
         # ----------------------- Create evaluation environment ---------------------- #
         eval_env = create_environment(

--- a/scripts/train/sweep_confs/train_agent_sweep_conf.py
+++ b/scripts/train/sweep_confs/train_agent_sweep_conf.py
@@ -251,9 +251,11 @@ def train():
 
             # By default, the evaluation environment does not use WandBLogger
             if wrappers:
-                key_to_remove = [key for key in wrappers if 'WandBLogger' in key][0]
-                del wrappers[key_to_remove]
-                logger.info(f'Wrappers updated without WandBLogger for evaluations')
+                wandb_keys = [key for key in wrappers if 'WandBLogger' in key]
+                if wandb_keys:
+                    del wrappers[wandb_keys[0]]
+                    logger.info(f'Wrappers updated without WandBLogger for evaluations')
+
             # ----------------------- Create evaluation environment ---------------------- #
             eval_env = create_environment(
                 env_id=wandb.config['environment'],


### PR DESCRIPTION
## 🚀 Description

Fix train agent scripts to prevent errors when WandBLogger is not used.


---

## 🔄 Types of Changes
<!-- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (change that alters existing functionality)
- [ ] 📖 Documentation update
- [ ] 🔧 Improvement (enhancement of an existing feature)
- [ ] 🏷️ Other (please specify below)


---

## ✅ Checklist
<!-- Go through the following points and check all that apply. -->
<!-- If you're unsure about any, feel free to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTION GUIDE](https://github.com/ugr-sail/sinergym/blob/main/CONTRIBUTING.md) (**required**).
- [ ] My changes require an update in the documentation.
- [ ] I have updated the tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `black --check <project-root-path>`.
- [ ] I have reformatted the code using `ruff check <project-root-path>`.
- [ ] I have ensured `cd docs && make spelling && make html` passes (**required** if documentation was updated).
- [ ] I have ensured `pytest tests/ -vv` passes (**required**).
- [ ] I have ensured `pyright <project-root-path>` passes (**required**).

---

## 📜 Automatic Changelog

<!-- 🚨 DO NOT EDIT: This section will be automatically populated with commit messages. -->

<details>
  <summary>🔽 Click to view changelog</summary>
  <!-- GitHub Actions will insert commit messages here -->
</details>